### PR TITLE
Add `mkrepo.username`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,19 @@ Create directory and `git init` and initial commit in imitation of [ghq](https:/
 
 ### Installation
 
-1. `cargo install mkrepo`
-2. Add ghq.root and user.name and service in your `~/.gitconfig`
+```
+cargo install mkrepo
+```
+
+### Usage
+
+`mkrepo` requires following `.gitconfig` values.
+
+- `ghq.root`
+- `mkrepo.service`
+- `mkrepo.username` or `user.name`
+
+Add these values to your `~/.gitconfig`.
 
 ```
 [user]
@@ -14,10 +25,8 @@ name="himanoa"
 root="~/src"
 [mkrepo]
 service="github.com"
+username="himanoa"
 ```
-
-
-### Usage
 
 #### Simple
 


### PR DESCRIPTION
For some people (including me), `user.name` differs from the GitHub username. This option will make their  experience better.

```gitconfig
[user]
	name = Ryo Yamashita
	email = qryxip@gmail.com
[ghq]
	root = ~/src
[mkrepo]
	service = github.com
	username = qryxip
```